### PR TITLE
ci: add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Publishing a release is the whole trigger: you create it with the version tag, this
+# checks that the tag is safe to serve and then moves the major tag to it.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Must match the version check-dist.yml builds with. The committed dist/ is
+      # whatever that produced, and a different major here can rewrite the bundle for
+      # reasons that have nothing to do with the source.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - run: npm ci
+
+      - run: |
+          npm run build
+          npm run package
+
+      # dist/index.js is what a workflow using this action actually runs, so a tag whose
+      # dist/ does not match its source serves code the repository does not show. That is
+      # checked on pull requests, but a tag can be cut from any commit, and the moment it
+      # is wrong is the moment it is hardest to notice.
+      - name: dist/ must match the source at this tag
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            git diff --stat dist/
+            echo "::error::dist/ is stale at ${{ github.ref_name }}. Rebuild it and retag before releasing."
+            exit 1
+          fi
+
+      # Skipped for prereleases: @v7 is what people who want a working action are pinned
+      # to, and a preview is not what they asked for. Prereleases are used by their full
+      # tag, which the release itself already provides.
+      #
+      # Asked twice, because the two catch different mistakes. The checkbox is the intent
+      # and can be forgotten; a version part after a hyphen is a prerelease by definition
+      # and cannot be. Either one is enough to leave the major tag alone.
+      - name: Move the major tag
+        if: ${{ !github.event.release.prerelease }}
+        run: |
+          major="${GITHUB_REF_NAME%%.*}"
+
+          if [ "$major" = "$GITHUB_REF_NAME" ]; then
+            echo "::error::${GITHUB_REF_NAME} has no version part to take a major from."
+            exit 1
+          fi
+
+          case "$GITHUB_REF_NAME" in
+            *-*)
+              echo "${GITHUB_REF_NAME} is a prerelease version. Leaving $major where it is."
+              exit 0
+              ;;
+          esac
+
+          echo "Pointing $major at ${GITHUB_REF_NAME} ($GITHUB_SHA)"
+          git tag -f "$major" "$GITHUB_SHA"
+          git push -f origin "refs/tags/$major"


### PR DESCRIPTION
Tagging and moving the major tag have been manual since v1. This does both from a published release, and checks the tag is safe to serve before it does.

You publish a release with tag `v7.0.0`; the workflow verifies `dist/` and moves `v7` to it.

### Why it verifies `dist/`

`dist/index.js` is what a workflow using this action actually runs. `check-dist.yml` verifies it on pull requests and pushes to `main` — but a tag can be cut from any commit, and a tag whose `dist/` does not match its source serves code the repository does not show.

That is the one failure here nobody would notice: the action keeps working, just not as the source says. So the release rebuilds the bundle and refuses to publish a tag it does not agree with.

### The major tag is left alone for prereleases

`v7.0.0-preview-1` is the next release. Pointing `@v7` at it would hand a preview to everyone pinned there who wanted a working action.

Two signals are treated as saying prerelease, because they fail in different ways:

| signal | catches |
|---|---|
| the release's `prerelease` checkbox | a deliberately-marked prerelease on an ordinary-looking tag |
| a version part after a hyphen | the checkbox being forgotten |

Either one is enough to leave the major tag where it is.

### Verified

The tag gate, against the tags this repo will actually use:

| tag | result |
|---|---|
| `v7.0.0` | moves `v7` |
| `v7.1.0` | moves `v7` |
| `v7.0.0-preview-1` | skipped, `v7` untouched |
| `v7` | error — no version part to take a major from |

That last one guards against releasing with the floating tag's own name.

### One coupling to know about

Node is pinned to `24.x` to match what `check-dist.yml` builds with — a different major can rewrite the bundle for reasons unrelated to the source, which would fail the `dist/` check for nothing.

`check-dist.yml` on `main` is currently `20.x`; #327 moves it to `24.x`. **This should merge after #327**, or the two disagree until it does. Nothing releases in that window, so it is not urgent — but if they ever drift again, the symptom is a release failing on a `dist/` diff nobody introduced.

A `.nvmrc` read by all three workflows via `node-version-file` would remove the duplication for good. Left out of this PR as it touches `check-dist.yml` and `test.yml` too.